### PR TITLE
Updated dockerfile to use boron-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:boron-alpine
 # Create app directory
 WORKDIR /usr/src/app
 # Install app dependencies


### PR DESCRIPTION
Its working fine and is a much smaller image.
104.6 MB for boron-alpine vs ~350mb for boron.
